### PR TITLE
Added animation loading in Tiles

### DIFF
--- a/CoolEngine/Engine/TileMap/TileMap/Tile.cpp
+++ b/CoolEngine/Engine/TileMap/TileMap/Tile.cpp
@@ -6,9 +6,9 @@ Tile::Tile() : GameObject()
 Tile::Tile(wstring path, int animFrames, int ID, string identifier) : GameObject(identifier)
 {
 	InitEdges();
+	InitAnimation(path);
 
 	m_ID = ID;
-	m_animFrames = animFrames;
 	
 }
 
@@ -43,18 +43,10 @@ void Tile::SetEdgeE(bool E)
 	m_edgeE = E;
 }
 
-void Tile::InitSprites()
+void Tile::InitAnimation(wstring animPath)
 {
-	if (m_animFrames > 1)
-	{
-		LoadAnimSprites();
-	}
+	AddAnimation("default", animPath);
 	return;
-}
-
-void Tile::LoadAnimSprites()
-{
-	//loadAnimSprite();
 }
 
 void Tile::InitEdges()

--- a/CoolEngine/Engine/TileMap/TileMap/Tile.h
+++ b/CoolEngine/Engine/TileMap/TileMap/Tile.h
@@ -16,8 +16,7 @@ public:
 
 	//Setup
 
-	void InitSprites();
-	void LoadAnimSprites();
+	void InitAnimation(wstring animPath);
 
 	//Getters
 
@@ -41,9 +40,6 @@ protected:
 private:
 	bool m_edgeN, m_edgeS, m_edgeW, m_edgeE;
 	int	 m_ID = -25;
-
-	int  m_animFrames = 1;
-	vector<ID3D11ShaderResourceView*> m_sprites[1] = {};
 
 	void InitEdges();
 };


### PR DESCRIPTION
Tiles now take a given wstring in the constructor to load an animation. This is handled and then stored in its parent gameObject.