### PR TITLE
SceneGraph Fix

### DIFF
--- a/CoolEngine/Engine/EditorUI/EditorUI.cpp
+++ b/CoolEngine/Engine/EditorUI/EditorUI.cpp
@@ -188,12 +188,21 @@ void EditorUI::DrawSceneGraphWindow()
 		if (ppayload != nullptr)
 		{
 			TreeNode<GameObject>* objectPointer = *(TreeNode<GameObject>**)ppayload->Data;
-
-			pgameManager->GetCurrentScene()->GetSceneGraph()->MoveNode(objectPointer, nullptr);
+			if (objectPointer->PreviousParent != nullptr)
+			{
+				pgameManager->GetCurrentScene()->GetSceneGraph()->MoveNode(objectPointer, nullptr);
+			}
 		}
 
 		ImGui::EndDragDropTarget();
 	}
+
+	if (ImGui::IsItemClicked())
+	{
+		m_gameObjectNodeClicked = -1;
+		pgameManager->SelectGameObject(nullptr);
+	}
+	
 	ImGui::End();
 
 	if (m_createGameObjectClicked)
@@ -375,18 +384,8 @@ void EditorUI::TraverseTree(TreeNode<GameObject>* pcurrentNode, int& nodeCount)
 	
 	if (ImGui::IsItemClicked() && !ImGui::IsItemToggledOpen())
 	{
-		if (nodeCount == m_gameObjectNodeClicked)
-		{
-			m_gameObjectNodeClicked = -1;
-			pgameManager->SelectGameObject(nullptr);
-
-
-		}
-		else
-		{
-			m_gameObjectNodeClicked = nodeCount;
-			pgameManager->SelectGameObjectUsingTreeNode(pcurrentNode);
-		}
+		m_gameObjectNodeClicked = nodeCount;
+		pgameManager->SelectGameObjectUsingTreeNode(pcurrentNode);
 	}
 
 

--- a/CoolEngine/Engine/Managers/SceneGraph.cpp
+++ b/CoolEngine/Engine/Managers/SceneGraph.cpp
@@ -107,6 +107,7 @@ void SceneGraph<T>::MoveNode(TreeNode<T>* currentNode, TreeNode<T>* parentNode)
 	currentNode->PreviousSibling = nullptr;
 	currentNode->Sibling = nullptr;
 
+	Transform* newParentTransform;
 	if (parentNode)
 	{
 		if (!parentNode->Child)
@@ -124,6 +125,8 @@ void SceneGraph<T>::MoveNode(TreeNode<T>* currentNode, TreeNode<T>* parentNode)
 			siblingNode->Sibling = currentNode;
 			currentNode->PreviousSibling = siblingNode;
 		}
+		newParentTransform = parentNode->NodeObject->GetTransform();
+		newParentTransform->AddChildTransform(currentTransform);
 	}
 	else
 	{
@@ -134,11 +137,10 @@ void SceneGraph<T>::MoveNode(TreeNode<T>* currentNode, TreeNode<T>* parentNode)
 		}
 		siblingNode->Sibling = currentNode;
 		currentNode->PreviousSibling = siblingNode;
+
+		newParentTransform = nullptr;
 	}
 
-	Transform* newParentTransform = m_rootNode->NodeObject->GetTransform();
-
-	newParentTransform->AddChildTransform(currentTransform);
 	currentTransform->SetParentTransform(newParentTransform);
 }
 


### PR DESCRIPTION
- Fixed an issue where unparenting a nested scene graph node would not update its transform hierarchy order.
- Made usability changes to scene graph UI, so clicking on already selected node in the window will no longer unselect it. Nodes can instead be unselected by clicking on an empty area of the window