### PR TITLE
When entering Zero as the options on the tilemap creator defaults are entered instead

### DIFF
--- a/CoolEngine/Engine/Tools/TileMapTool.cpp
+++ b/CoolEngine/Engine/Tools/TileMapTool.cpp
@@ -179,9 +179,9 @@ void TileMapTool::EnsureTileSizesAreValid()
         m_tileMapHeight = 1;
     }
 
-    if (m_tileDimensions < m_miniumScale)
+    if (m_tileDimensions < m_minimumScale)
     {
-        m_tileDimensions = m_miniumScale;
+        m_tileDimensions = m_minimumScale;
     }
 }
 #endif

--- a/CoolEngine/Engine/Tools/TileMapTool.h
+++ b/CoolEngine/Engine/Tools/TileMapTool.h
@@ -24,7 +24,7 @@ public:
     /// <summary>
     /// The smallest size a tile may be when creating tilesets in the system
     /// </summary>
-    const int m_miniumScale = 4;
+    const int m_minimumScale = 4;
 
 protected:
 


### PR DESCRIPTION
1. Due some divide by zeros in the tilemap creator it is rather easy to crash the editor. Therefore when entering zero in this area this change simply defaults the options to reasonable numbers.

![image](https://user-images.githubusercontent.com/44545313/167806053-c3a9418f-a38c-4a91-afdf-08285c00d2dc.png)
This is the size of the scale within there. 