### PR TITLE
Weapons in inventory may now be displayed on the UI.

### DIFF
--- a/CoolEngine/Engine/GameUI/GameplayIntegration/GameplayUIPickupAttachement.cpp
+++ b/CoolEngine/Engine/GameUI/GameplayIntegration/GameplayUIPickupAttachement.cpp
@@ -55,6 +55,11 @@ GameplayUIPickupAttachement::~GameplayUIPickupAttachement()
 /// </summary>
 void GameplayUIPickupAttachement::Start()
 {
+    if (m_pickupSlot == 0)
+    {
+        return;
+    }
+
     AttemptToFindPlayer();
     m_playerPickedUpItem = true;
 }
@@ -64,6 +69,11 @@ void GameplayUIPickupAttachement::Start()
 /// </summary>
 void GameplayUIPickupAttachement::Update()
 {
+    if (m_pickupSlot == 0)
+    {
+        return;
+    }
+
     // This ensures we only update when data changes
     // see handle Player Pickups
     if (!m_playerPickedUpItem)

--- a/CoolEngine/Engine/GameUI/GameplayIntegration/GameplayUIWeaponAttachment.h
+++ b/CoolEngine/Engine/GameUI/GameplayIntegration/GameplayUIWeaponAttachment.h
@@ -3,8 +3,10 @@
 #include "Engine/GameObjects/PlayerGameObject.h"
 #include "Engine/GameObjects/WeaponGameObject.h"
 #include "Engine\GameUI\GameplayIntegration\EWeaponUIAttachmentOption.h"
+#include "Engine\Managers\Events\EventObserver.h"
+#include "Engine\Managers\Events\PickupEvent.h"
 
-class GameplayUIWeaponAttachment
+class GameplayUIWeaponAttachment : public Observer
 {
 public:
     GameplayUIWeaponAttachment();
@@ -43,6 +45,11 @@ public:
     /// Called when the UI element should update
     /// </summary>
     void Update();
+
+    /// <summary>
+    /// Handles events from the Observations
+    /// </summary>
+    void Handle(Event* e) override;
 
     void LoadFromTopLevel(const nlohmann::json& jsonData);
     void SaveFromTopLevel(nlohmann::json& jsonData);
@@ -106,6 +113,27 @@ private:
     /// </summary>
     /// <param name="weapon">Current weapon to display</param>
     void UpdatedUI(WeaponGameObject* weapon);
+
+    /// <summary>
+    /// Handles pickup events
+    /// </summary>
+    void PlayerPickedupItem(PickupEvent* e);
+
+    /// <summary>
+    /// True means we are safe to scan the inventory for a new weapon
+    /// </summary>
+    bool m_playerPickedUpItem;
+
+    /// <summary>
+    /// Gets the weapon in the inventory
+    /// </summary>
+    /// <returns>The weapon to use</returns>
+    WeaponGameObject* GetWeaponInInventory();
+
+    /// <summary>
+    /// Weapon currently in the players inventory. Can be nullptr.
+    /// </summary>
+    WeaponGameObject* m_weaponCurrentlyInInventory;
 
 #if EDITOR
     list<pair<int, string>> m_attachmentSettingList;

--- a/CoolEngine/Engine/GameUI/GameplayIntegration/ImageUIWeaponDisplay.cpp
+++ b/CoolEngine/Engine/GameUI/GameplayIntegration/ImageUIWeaponDisplay.cpp
@@ -44,29 +44,21 @@ void ImageUIWeaponDisplay::Start()
 /// <param name="weaponGameObject">The weapon to display</param>
 void ImageUIWeaponDisplay::Update(WeaponGameObject* weaponGameObject)
 {
-	switch (m_weaponAttachmentOption)
-	{
-		case EWEAPONUIATTACHMENTOPTION::Holding:
-			if (weaponGameObject != nullptr && m_texturePathAttached == std::wstring())
-			{
-				m_imageComponent->SetTexture(weaponGameObject->GetUITexturePath());
-			}
-			else
-			{
-				m_imageComponent->SetTexture(m_texturePathAttached);
-			}
-			break;
-		case EWEAPONUIATTACHMENTOPTION::Inventory:
-			if (weaponGameObject != nullptr && m_texturePathAttached == std::wstring())
-			{
-				m_imageComponent->SetTexture(weaponGameObject->GetUITexturePath());
-			}
-			else
-			{
-				m_imageComponent->SetTexture(m_texturePathNotAttached);
-			}
-		break;
-	}
+    if (weaponGameObject != nullptr)
+    {
+        if (m_texturePathAttached == std::wstring())
+        {
+            m_imageComponent->SetTexture(weaponGameObject->GetUITexturePath());
+        }
+        else
+        {
+            m_imageComponent->SetTexture(m_texturePathAttached);
+        }
+    }
+    else
+    {
+        m_imageComponent->SetTexture(m_texturePathNotAttached);
+    }
 }
 
 #if EDITOR
@@ -79,14 +71,14 @@ void ImageUIWeaponDisplay::Update(WeaponGameObject* weaponGameObject)
 
 			float colWidth = 150;
 			ImVec2 imageSize = ImVec2(100, 100);
-			EditorUI::Texture("Image if held", m_texturePathAttached, m_ptextureWeaponAttached, colWidth, imageSize);
+			EditorUI::Texture("Image if full", m_texturePathAttached, m_ptextureWeaponAttached, colWidth, imageSize);
 
 			if (EditorUI::BasicButton("Reset Image Held"))
 			{
 				SetAttachedTexture(std::wstring());
 			}
 
-			EditorUI::Texture("Image if not held", m_texturePathNotAttached, m_ptextureWeaponNotAttached, colWidth, imageSize);
+			EditorUI::Texture("Image if empty", m_texturePathNotAttached, m_ptextureWeaponNotAttached, colWidth, imageSize);
 
 			if (EditorUI::BasicButton("Reset Image Not Held"))
 			{


### PR DESCRIPTION
1. Weapons in inventory may now be displayed.
2. This had to be done slightly differently to pickups where it just updates on pickup but continually uses a pointer which updates. The difference is just to allow the difference between GetWeapon and the inventory.